### PR TITLE
Define custom log file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [log] Allow to set output file for logging (default is os.Stdout), can be os.Stderr, any file pointer or nil to disable logging
+
 ### Deprecated
 
 ### Removed

--- a/pkg/log/encoder.go
+++ b/pkg/log/encoder.go
@@ -90,3 +90,16 @@ func (e *PrettyEncoder) Encode(entry interface{}) error {
 func NewPrettyEncoder(w io.Writer) Encoder {
 	return &PrettyEncoder{out: w}
 }
+
+// NullEncoder is an encoder that discards all log entries
+type NullEncoder struct{}
+
+// Encode does nothing and returns no error, effectively discarding the log entry
+func (e *NullEncoder) Encode(v interface{}) error {
+	return nil
+}
+
+// NewNullEncoder creates a new null encoder that discards all log entries
+func NewNullEncoder() Encoder {
+	return &NullEncoder{}
+}

--- a/pkg/log/encoder.go
+++ b/pkg/log/encoder.go
@@ -95,7 +95,7 @@ func NewPrettyEncoder(w io.Writer) Encoder {
 type NullEncoder struct{}
 
 // Encode does nothing and returns no error, effectively discarding the log entry
-func (e *NullEncoder) Encode(v interface{}) error {
+func (e *NullEncoder) Encode(_ interface{}) error {
 	return nil
 }
 


### PR DESCRIPTION
This PR allows to set an output file other than os.Stdout (default) via `logging.OutputFile(...)`. So, it could be os.Stderr, any file pointer or nil to disable logging completely:
```
	logging.LoggerConfig(logging.Unnamed(), logging.Debug(false), logging.HumanReadable(false), logging.OutputFile(nil))
```