### PR TITLE
Release v1.92.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [standard] Add WithPathPrefixStrip middleware to strip path prefix from request URLs (fixes AGIC+gRPC issue)
-
 ### Changed
 
 ### Deprecated
@@ -20,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## [v1.92.0] - 2026-04-05
+
+### Added
+
+- [standard] Add WithPathPrefixStrip middleware to strip path prefix from request URLs (fixes AGIC+gRPC issue)
 
 ## [v1.91.1] - 2026-03-24
 
@@ -1072,7 +1076,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial state: standards for Main, HTTP Server, DB access (gorm), Logging, Instrumented-Handler, and K8s Probe
 
-[Unreleased]: https://github.com/d4l-data4life/go-svc/compare/v1.91.1...HEAD
+[Unreleased]: https://github.com/d4l-data4life/go-svc/compare/v1.92.0...HEAD
+[v1.92.0]: https://github.com/d4l-data4life/go-svc/compare/v1.91.1...v1.92.0
 [v1.91.1]: https://github.com/d4l-data4life/go-svc/compare/v1.91.0...v1.91.1
 [v1.91.0]: https://github.com/d4l-data4life/go-svc/compare/v1.90.0...v1.91.0
 [v1.90.0]: https://github.com/d4l-data4life/go-svc/compare/v1.89.0...v1.90.0


### PR DESCRIPTION
# Release v1.92.0
### Added

- [standard] Add WithPathPrefixStrip middleware to strip path prefix from request URLs (fixes AGIC+gRPC issue)

